### PR TITLE
Inherits() uses go url.ResolveReference(), fixes relative $ref

### DIFF
--- a/reference_test.go
+++ b/reference_test.go
@@ -15,12 +15,12 @@
 // author  			sigu-399
 // author-github 	https://github.com/sigu-399
 // author-mail		sigu.399@gmail.com
-// 
+//
 // repository-name	gojsonreference
 // repository-desc	An implementation of JSON Reference - Go language
-// 
+//
 // description		Automated tests on package.
-// 
+//
 // created      	03-03-2013
 
 package gojsonreference
@@ -57,6 +57,10 @@ func TestFull(t *testing.T) {
 	if r1.HasFileScheme != false {
 		t.Errorf("NewJsonReference(%v)::HasFileScheme %v expect %v", in, r1.HasFileScheme, false)
 	}
+
+	if r1.GetPointer().String() != "/f/a/b" {
+		t.Errorf("NewJsonReference(%v)::GetPointer() %v expect %v", in, r1.GetPointer().String(), "/f/a/b")
+	}
 }
 
 func TestFullUrl(t *testing.T) {
@@ -86,6 +90,10 @@ func TestFullUrl(t *testing.T) {
 
 	if r1.HasFileScheme != false {
 		t.Errorf("NewJsonReference(%v)::HasFileScheme %v expect %v", in, r1.HasFileScheme, false)
+	}
+
+	if r1.GetPointer().String() != "" {
+		t.Errorf("NewJsonReference(%v)::GetPointer() %v expect %v", in, r1.GetPointer().String(), "")
 	}
 }
 
@@ -117,6 +125,10 @@ func TestFragmentOnly(t *testing.T) {
 	if r1.HasFileScheme != false {
 		t.Errorf("NewJsonReference(%v)::HasFileScheme %v expect %v", in, r1.HasFileScheme, false)
 	}
+
+	if r1.GetPointer().String() != "/fragment/only" {
+		t.Errorf("NewJsonReference(%v)::GetPointer() %v expect %v", in, r1.GetPointer().String(), "/fragment/only")
+	}
 }
 
 func TestUrlPathOnly(t *testing.T) {
@@ -147,6 +159,44 @@ func TestUrlPathOnly(t *testing.T) {
 	if r1.HasFileScheme != false {
 		t.Errorf("NewJsonReference(%v)::HasFileScheme %v expect %v", in, r1.HasFileScheme, false)
 	}
+
+	if r1.GetPointer().String() != "" {
+		t.Errorf("NewJsonReference(%v)::GetPointer() %v expect %v", in, r1.GetPointer().String(), "")
+	}
+}
+
+func TestUrlRelativePathOnly(t *testing.T) {
+
+	in := "document.json"
+
+	r1, err := NewJsonReference(in)
+	if err != nil {
+		t.Errorf("NewJsonReference(%v) error %s", in, err.Error())
+	}
+
+	if in != r1.String() {
+		t.Errorf("NewJsonReference(%v) = %v, expect %v", in, r1.String(), in)
+	}
+
+	if r1.HasFragmentOnly != false {
+		t.Errorf("NewJsonReference(%v)::HasFragmentOnly %v expect %v", in, r1.HasFragmentOnly, false)
+	}
+
+	if r1.HasFullUrl != false {
+		t.Errorf("NewJsonReference(%v)::HasFullUrl %v expect %v", in, r1.HasFullUrl, false)
+	}
+
+	if r1.HasUrlPathOnly != true {
+		t.Errorf("NewJsonReference(%v)::HasUrlPathOnly %v expect %v", in, r1.HasUrlPathOnly, true)
+	}
+
+	if r1.HasFileScheme != false {
+		t.Errorf("NewJsonReference(%v)::HasFileScheme %v expect %v", in, r1.HasFileScheme, false)
+	}
+
+	if r1.GetPointer().String() != "" {
+		t.Errorf("NewJsonReference(%v)::GetPointer() %v expect %v", in, r1.GetPointer().String(), "")
+	}
 }
 
 func TestInheritsValid(t *testing.T) {
@@ -166,9 +216,13 @@ func TestInheritsValid(t *testing.T) {
 	if result.String() != out {
 		t.Errorf("Inherits(%s,%s) = %s, expect %s", r1.String(), r2.String(), result.String(), out)
 	}
+
+	if result.GetPointer().String() != "/a/b" {
+		t.Errorf("result(%v)::GetPointer() %v expect %v", result.String(), result.GetPointer().String(), "/a/b")
+	}
 }
 
-func TestInheritsInvalid(t *testing.T) {
+func TestInheritsDifferentHost(t *testing.T) {
 
 	in1 := "http://www.test.com/doc.json"
 	in2 := "http://www.test2.com/doc.json#bla"
@@ -176,11 +230,19 @@ func TestInheritsInvalid(t *testing.T) {
 	r1, _ := NewJsonReference(in1)
 	r2, _ := NewJsonReference(in2)
 
-	_, err := r1.Inherits(r2)
-	if err == nil {
-		t.Errorf("Inherits(%s,%s) should fail", r1.String(), r2.String())
+	result, err := r1.Inherits(r2)
+
+	if err != nil {
+		t.Errorf("Inherits(%s,%s) should not fail. Error: %s", r1.String(), r2.String(), err.Error())
 	}
 
+	if result.String() != in2 {
+		t.Errorf("Inherits(%s,%s) should be %s but is %s", in1, in2, in2, result)
+	}
+
+	if result.GetPointer().String() != "" {
+		t.Errorf("result(%v)::GetPointer() %v expect %v", result.String(), result.GetPointer().String(), "")
+	}
 }
 
 func TestFileScheme(t *testing.T) {
@@ -207,9 +269,110 @@ func TestFileScheme(t *testing.T) {
 		t.Errorf("NewJsonReference(%v)::IsCanonical %v expect %v", in1, r1.IsCanonical, true)
 	}
 
-	_, err := r1.Inherits(r2)
+	result, err := r1.Inherits(r2)
 	if err != nil {
-		t.Errorf("Inherits(%s,%s) error %s", r1.String(), r2.String(), err.Error())
+		t.Errorf("Inherits(%s,%s) should not fail. Error: %s", r1.String(), r2.String(), err.Error())
+	}
+	if result.String() != in2 {
+		t.Errorf("Inherits(%s,%s) should be %s but is %s", in1, in2, in2, result)
 	}
 
+	if result.GetPointer().String() != "" {
+		t.Errorf("result(%v)::GetPointer() %v expect %v", result.String(), result.GetPointer().String(), "")
+	}
+}
+
+func TestReferenceResolution(t *testing.T) {
+
+	// 5.4. Reference Resolution Examples
+	// http://tools.ietf.org/html/rfc3986#section-5.4
+
+	base := "http://a/b/c/d;p?q"
+	baseRef, err := NewJsonReference(base)
+
+	if err != nil {
+		t.Errorf("NewJsonReference(%s) failed error: %s", base, err.Error())
+	}
+	if baseRef.String() != base {
+		t.Errorf("NewJsonReference(%s) %s expected %s", base, baseRef.String(), base)
+	}
+
+	checks := []string{
+		// 5.4.1. Normal Examples
+		// http://tools.ietf.org/html/rfc3986#section-5.4.1
+
+		"g:h", "g:h",
+		"g", "http://a/b/c/g",
+		"./g", "http://a/b/c/g",
+		"g/", "http://a/b/c/g/",
+		"/g", "http://a/g",
+		"//g", "http://g",
+		"?y", "http://a/b/c/d;p?y",
+		"g?y", "http://a/b/c/g?y",
+		"#s", "http://a/b/c/d;p?q#s",
+		"g#s", "http://a/b/c/g#s",
+		"g?y#s", "http://a/b/c/g?y#s",
+		";x", "http://a/b/c/;x",
+		"g;x", "http://a/b/c/g;x",
+		"g;x?y#s", "http://a/b/c/g;x?y#s",
+		"", "http://a/b/c/d;p?q",
+		".", "http://a/b/c/",
+		"./", "http://a/b/c/",
+		"..", "http://a/b/",
+		"../", "http://a/b/",
+		"../g", "http://a/b/g",
+		"../..", "http://a/",
+		"../../", "http://a/",
+		"../../g", "http://a/g",
+
+		// 5.4.2. Abnormal Examples
+		// http://tools.ietf.org/html/rfc3986#section-5.4.2
+
+		"../../../g", "http://a/g",
+		"../../../../g", "http://a/g",
+
+		"/./g", "http://a/g",
+		"/../g", "http://a/g",
+		"g.", "http://a/b/c/g.",
+		".g", "http://a/b/c/.g",
+		"g..", "http://a/b/c/g..",
+		"..g", "http://a/b/c/..g",
+
+		"./../g", "http://a/b/g",
+		"./g/.", "http://a/b/c/g/",
+		"g/./h", "http://a/b/c/g/h",
+		"g/../h", "http://a/b/c/h",
+		"g;x=1/./y", "http://a/b/c/g;x=1/y",
+		"g;x=1/../y", "http://a/b/c/y",
+
+		"g?y/./x", "http://a/b/c/g?y/./x",
+		"g?y/../x", "http://a/b/c/g?y/../x",
+		"g#s/./x", "http://a/b/c/g#s/./x",
+		"g#s/../x", "http://a/b/c/g#s/../x",
+
+		"http:g", "http:g", // for strict parsers
+		//"http:g", "http://a/b/c/g", // for backward compatibility
+
+	}
+	for i := 0; i < len(checks); i += 2 {
+		child := checks[i]
+		expected := checks[i+1]
+		// fmt.Printf("%d:   %v  ->  %v\n", i/2, child, expected)
+
+		childRef, e := NewJsonReference(child)
+		if e != nil {
+			t.Errorf("%d: NewJsonReference(%s) failed error: %s", i/2, child, e.Error())
+		}
+
+		res, e := baseRef.Inherits(childRef)
+		if res == nil {
+			t.Errorf("%d: Inherits(%s, %s) nil not expected", i/2, base, child)
+		}
+		if e != nil {
+			t.Errorf("%d: Inherits(%s) failed error: %s", i/2, child, e.Error())
+		}
+		if res.String() != expected {
+			t.Errorf("%d: Inherits(%s, %s) %s expected %s", i/2, base, child, res.String(), expected)
+		}
+	}
 }


### PR DESCRIPTION
Uses golang `url.ResolveReference()` to implement `Inherits()` logic. Manual implementations of `inheritsImplHttp()` and `inheritsImplFile` no longer needed. All handled by `url.ResolveReference()` out of the box.

Simplified `parse()`

Added RFC3986 examples as tests.

https://github.com/janmentzel/gojsonschema tests still pass.
