### PR TITLE
Fixed JsonReference.HasFullFilePath to be set correctly on Windows

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -29,7 +29,7 @@ import (
 	"errors"
 	"github.com/xeipuuv/gojsonpointer"
 	"net/url"
-	"strings"
+	"path/filepath"
 )
 
 const (
@@ -100,7 +100,7 @@ func (r *JsonReference) parse(jsonReferenceString string) (err error) {
 	}
 
 	r.HasFileScheme = refUrl.Scheme == "file"
-	r.HasFullFilePath = strings.HasPrefix(refUrl.Path, "/")
+	r.HasFullFilePath = filepath.IsAbs(refUrl.Path)
 
 	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
 	r.referencePointer, _ = gojsonpointer.NewJsonPointer(refUrl.Fragment)


### PR DESCRIPTION
See https://github.com/xeipuuv/gojsonreference/issues/4

In particular, this was fixed in the go language with this patch:
https://codereview.appspot.com/3989064/patch/35004/46006

Thanks!