### PR TITLE
Reverting my previous fix

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -29,7 +29,7 @@ import (
 	"errors"
 	"github.com/xeipuuv/gojsonpointer"
 	"net/url"
-	"path/filepath"
+	"strings"
 )
 
 const (
@@ -100,7 +100,7 @@ func (r *JsonReference) parse(jsonReferenceString string) (err error) {
 	}
 
 	r.HasFileScheme = refUrl.Scheme == "file"
-	r.HasFullFilePath = filepath.IsAbs(refUrl.Path)
+	r.HasFullFilePath = strings.HasPrefix(refUrl.Path, "/")
 
 	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
 	r.referencePointer, _ = gojsonpointer.NewJsonPointer(refUrl.Fragment)


### PR DESCRIPTION
This reverts commit 9ecd8572a027941b36249df5da0aec0ee7a1673d since this
particular fix was not correct. Apologies for not testing this more thoroughly.

The original implementation is actually fine if forward slashes are used on Windows rather than backslashes.

Please see https://github.com/xeipuuv/gojsonreference/issues/4 for more details.