### PR TITLE
Fix inheritance if the child's fragment is empty

### DIFF
--- a/reference.go
+++ b/reference.go
@@ -27,11 +27,12 @@ package gojsonreference
 
 import (
 	"errors"
-	"github.com/xeipuuv/gojsonpointer"
 	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/xeipuuv/gojsonpointer"
 )
 
 const (
@@ -124,16 +125,21 @@ func (r *JsonReference) parse(jsonReferenceString string) (err error) {
 // Creates a new reference from a parent and a child
 // If the child cannot inherit from the parent, an error is returned
 func (r *JsonReference) Inherits(child JsonReference) (*JsonReference, error) {
-	childUrl := child.GetUrl()
-	parentUrl := r.GetUrl()
-	if childUrl == nil {
+	if child.GetUrl() == nil {
 		return nil, errors.New("childUrl is nil!")
 	}
-	if parentUrl == nil {
+
+	if r.GetUrl() == nil {
 		return nil, errors.New("parentUrl is nil!")
 	}
 
-	ref, err := NewJsonReference(parentUrl.ResolveReference(childUrl).String())
+	// Get a copy of the parent url to make sure we do not modify the original.
+	// URL reference resolving fails if the fragment of the child is empty, but the parent's is not.
+	// The fragment of the child must be used, so the fragment of the parent is manually removed.
+	parentUrl := *r.GetUrl()
+	parentUrl.Fragment = ""
+
+	ref, err := NewJsonReference(parentUrl.ResolveReference(child.GetUrl()).String())
 	if err != nil {
 		return nil, err
 	}

--- a/reference_test.go
+++ b/reference_test.go
@@ -245,6 +245,24 @@ func TestInheritsDifferentHost(t *testing.T) {
 	}
 }
 
+func TestInheritsEmptyFragment(t *testing.T) {
+	in1 := "#a"
+	in2 := ""
+
+	r1, _ := NewJsonReference(in1)
+	r2, _ := NewJsonReference(in2)
+
+	result, err := r1.Inherits(r2)
+
+	if err != nil {
+		t.Errorf("Inherits(%s,%s) should not fail. Error: %s", r1.String(), r2.String(), err.Error())
+	}
+
+	if result.String() != in2 {
+		t.Errorf("Inherits(%s,%s) should be empty but is %s", in1, in2, result)
+	}
+}
+
 func TestFileScheme(t *testing.T) {
 
 	in1 := "file:///Users/mac/1.json#a"
@@ -266,7 +284,7 @@ func TestFileScheme(t *testing.T) {
 	}
 
 	if r1.IsCanonical() != true {
-		t.Errorf("NewJsonReference(%v)::IsCanonical %v expect %v", in1, r1.IsCanonical, true)
+		t.Errorf("NewJsonReference(%v)::IsCanonical %v expect %v", in1, r1.IsCanonical(), true)
 	}
 
 	result, err := r1.Inherits(r2)


### PR DESCRIPTION
If the fragment of a child reference is empty and is a relative URL (so basically it's completely empty), the fragment of the resulting reference should also be empty, but up till now the fragment of the parent was used. The fragment of the parent should actually never be used and should therefore always be removed.